### PR TITLE
Change /create link to /linkdrop link

### DIFF
--- a/src/near/config.js
+++ b/src/near/config.js
@@ -28,7 +28,7 @@ const configs = {
 const createHelpers = (config) => ({
   getCheckAccountInExplorerUrl: (accountId) => `${config.explorerUrl}/accounts/${accountId}`,
   getCreateAccountAndClaimLink: (secretKey, campaignAccountId) =>
-    `${config.walletUrl}/create/${campaignAccountId}/${secretKey}`,
+    `${config.walletUrl}/linkdrop/${campaignAccountId}/${secretKey}`,
 });
 
 const getNearConfig = (network) => {


### PR DESCRIPTION
This allows user to select whether to claim linkdrop on new or existing account